### PR TITLE
ATLAS-208 Remove "\n" characters in the REST API json response

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/resources/EntityResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/EntityResource.java
@@ -102,7 +102,7 @@ public class EntityResource {
 
             Response.Status status = Response.Status.NOT_FOUND;
             if (entityDefinition != null) {
-                response.put(AtlasClient.DEFINITION, entityDefinition);
+                response.put(AtlasClient.DEFINITION, new JSONObject(entityDefinition));
                 status = Response.Status.OK;
             } else {
                 response.put(AtlasClient.ERROR,
@@ -148,7 +148,7 @@ public class EntityResource {
 
             Response.Status status = Response.Status.NOT_FOUND;
             if (entityDefinition != null) {
-                response.put(AtlasClient.DEFINITION, entityDefinition);
+                response.put(AtlasClient.DEFINITION, new JSONObject(entityDefinition));
                 status = Response.Status.OK;
             } else {
                 response.put(AtlasClient.ERROR, Servlets.escapeJsonString(String.format("An entity with type={%s}, " +

--- a/webapp/src/main/java/org/apache/atlas/web/resources/TypesResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/TypesResource.java
@@ -123,7 +123,7 @@ public class TypesResource {
 
             JSONObject response = new JSONObject();
             response.put(AtlasClient.TYPENAME, typeName);
-            response.put(AtlasClient.DEFINITION, typeDefinition);
+            response.put(AtlasClient.DEFINITION, new JSONObject(typeDefinition));
             response.put(AtlasClient.REQUEST_ID, Servlets.getRequestId());
 
             return Response.ok(response).build();


### PR DESCRIPTION
Entity and Type definition string was directly getting added to response JSON object. converting it  to JSONObject before adding it into definition attribute of response object. 
This fixes "\n" issue in definition for below 3 API which are returning json with "\n"
api/atlas/types/{typeName}
api/atlas/entity/{guid}
api/atlas/entity? type,property,value

http://localhost:21000/api/atlas/types/Dimension
{"typeName":"Dimension",**"definition":{"enumTypes":[],"structTypes":[],"traitTypes":[{"superTypes":[],"hierarchicalMetaTypeName":"org.apache.atlas.typesystem.types.TraitType","typeName":"Dimension","attributeDefinitions":[]}],"classTypes":[]}**,"requestId":"qtp2027897550-12 - 7fd6a1d5-fece-49d7-a422-28ee7f2cf810"}